### PR TITLE
Add muting persistence

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -1,5 +1,7 @@
 
 bot_token = "<bot_token>"
+bot_shard_id = 0
+bot_shard_count = 1
 
 [default.guilds."<guild_id_here>"]
 

--- a/main.py
+++ b/main.py
@@ -18,7 +18,9 @@ intents = Intents.default()
 intents.message_content = True  # Enable sending messages
 intents.members = True
 bot = Bot("nana", intents=intents)
-
+# Optionally load the bot sharded, to support zero downtime.
+bot.shard_id = settings.get("bot_shard_id", None)
+bot.shard_count = settings.get("bot_shard_token", None)
 
 @bot.event
 async def on_ready():

--- a/main.py
+++ b/main.py
@@ -6,25 +6,13 @@ import intervals
 from ayumi import Ayumi
 from config import settings
 from datetime import datetime, timedelta, timezone
-from discord import Forbidden, Intents, Message
-from discord.ext import tasks
+from discord import Intents, Message
 from discord.ext.commands import Bot
-from queue import PriorityQueue
 
 # TODO: Add support for Cogs/Extensions
 
 DEFAULT_SAFE_MESSAGE = "You have a safe role, so you won't be muted :)"
 DEFAULT_MUTE_MESSAGE = "Oh no, you've been muted for {mute_duration_display_str}!"
-
-"""
-A set that contains every user currently under a mute status.
-
-This is a PriorityQueue holding elements of the following form:
-< (unmute_time_ms, user_id, guild_id, role_id) >
-
-Note: PriorityQueue is thread-safe; a thread lock does not need to be used.
-"""
-_muted_users = PriorityQueue(maxsize=0)
 
 intents = Intents.default()
 intents.message_content = True  # Enable sending messages
@@ -32,78 +20,9 @@ intents.members = True
 bot = Bot("nana", intents=intents)
 
 
-@tasks.loop(minutes=1.0)
-async def batch_unmute_users():
-    current_time = datetime.now(timezone.utc)
-    Ayumi.debug("Now starting batch unmute job. The current time is: {time}.".format(time=current_time.strftime("%c")))
-
-    while not _muted_users.empty():
-        # Fetch the first element (i.e. the next closest job) from the queue. Note that this is always a pop.
-        unmute_job = _muted_users.get(block=True)
-
-        unmute_job_time = unmute_job[0]
-        Ayumi.debug("Next unmute is scheduled at: {time}.".format(time=unmute_job_time.strftime("%c")))
-
-        # If the unmute time on the job has not passed yet, then all tasks are at a future time.
-        if current_time < unmute_job_time:
-            Ayumi.debug("Job is in a future time. Now exiting the batch unmute job.")
-            _muted_users.put(unmute_job)  # Return the job
-            return
-
-        unmute_job_user_id = unmute_job[1]
-        Ayumi.debug(f"Job has user id: {unmute_job_user_id}")
-        unmute_job_guild_id = unmute_job[2]
-        Ayumi.debug(f"Job has guild id: {unmute_job_guild_id}")
-        unmute_job_role_id = unmute_job[3]
-        Ayumi.debug(f"Job has (unmute) role id: {unmute_job_role_id}")
-
-        # Load the Guild object to perform the unmute.
-        guild = bot.get_guild(unmute_job_guild_id)
-        if not guild:
-            Ayumi.debug("Was not able to load Guild from local cache, requesting from Gateway...")
-            guild = await bot.fetch_guild(unmute_job_guild_id)
-        Ayumi.debug("Loaded Guild (name: {name}, id: {id}).".format(
-            name=guild.name,
-            id=guild.id))
-
-        # Load the User object from the Guild to perform the unmute.
-        user = await guild.fetch_member(unmute_job_user_id)
-        Ayumi.debug("Loaded Member (name: {name}, id: {id}).".format(
-            name=user.name,
-            id=user.id))
-
-        # Load the Role object to remove from the User.
-        mute_role = guild.get_role(unmute_job_role_id)
-        if not mute_role:
-            Ayumi.debug("Unable to load role from local Guild object, requesting from Gateway...")
-            await guild.fetch_roles()
-            mute_role = guild.get_role(unmute_job_role_id)
-        Ayumi.debug("Loaded role ({role_name}, {role_id}).".format(
-            role_name=mute_role.name,
-            role_id=mute_role.id))
-
-        # Perform the unmute.
-        try:
-            await user.remove_roles(mute_role, atomic=True)
-            Ayumi.info("Successfully removed mute from {user_name} ({user_display_name}).".format(
-                user_name=user.name,
-                user_display_name=user.display_name))
-        except Forbidden:
-            Ayumi.critical("Bot does not appear to have permissions to remove roles. Now exiting...")
-            await bot.close()
-            sys.exit(1)
-
-    Ayumi.debug("Queue is empty, exiting the batch unmute job.")
-    return
-
-
 @bot.event
 async def on_ready():
     Ayumi.info("Bot is ready.")
-
-    Ayumi.debug("Starting batch unmute job...")
-    batch_unmute_users.start()
-    Ayumi.info("Started batch unmute job.")
 
 
 @bot.event
@@ -187,9 +106,10 @@ async def on_message(message: Message):
                 message_content=message.content[:10]))
 
     mute_duration = intervals.generate_mute_time()  # Mute duration is in minutes (as int)
+    mute_duration_display_str = intervals.convert_minutes_to_display_str(mute_duration)
     Ayumi.info(
         "Generated mute time: {mute_time} ({mute_time_in_minutes} minutes).".format(
-            mute_time=intervals.convert_minutes_to_display_str(mute_duration),
+            mute_time=mute_duration_display_str,
             mute_time_in_minutes=mute_duration))
 
     # If the message author is a safe role, then do not mute them.
@@ -211,7 +131,7 @@ async def on_message(message: Message):
         await message.reply(
             safe_message_to_use.format(
                 safe_user_name=message.author.display_name,
-                mute_duration_display_str=intervals.convert_minutes_to_display_str(mute_duration)))
+                mute_duration_display_str=mute_duration_display_str))
         return
 
     # Calculate the time that the user will be unblocked.
@@ -219,43 +139,30 @@ async def on_message(message: Message):
     Ayumi.debug("The current time is: {current_time}".format(current_time=current_time.strftime("[UTC] %c")))
 
     mute_duration_as_delta = timedelta(minutes=mute_duration)
+
+    # TODO: Temporary block due to the Discord timeout being limited to 28 days.
+    if mute_duration_as_delta > timedelta(days=28):
+        mute_duration_as_delta = timedelta(days=28)
+        Ayumi.warning("WARNING: Generated a mute time above 28 days, trimming to 28 days. Check your configuration!")
+
     unmute_time = current_time + mute_duration_as_delta
     Ayumi.debug("The user will be unmuted at: {unmute_time}".format(unmute_time=unmute_time.strftime("[UTC] %c")))
 
-    # Mute the user by assigning the role.
-    mute_role_id = guild_settings.get("mute_role", None)
-    if not mute_role_id:
-        Ayumi.warning("No mute role ID found for guild {guild_name} ({guild_id}), will not mute user.".format(
-            guild_name=message.guild.name,
-            guild_id=message.guild.id))
-
-    Ayumi.debug("Loading role with id: ({role_id}) for the mute...".format(role_id=mute_role_id))
-    role_to_add = message.guild.get_role(mute_role_id)
-    if not role_to_add:
-        Ayumi.debug("Unable to load role locally, loading all roles from Gateway and retrying...")
-        await message.guild.fetch_roles()
-        role_to_add = message.guild.get_role(mute_role_id)
-    Ayumi.debug("Loaded role ({role_name}, {role_id}).".format(role_name=role_to_add.name, role_id=role_to_add.id))
-
-    await message.author.add_roles(role_to_add, atomic=True)
+    await message.author.timeout(mute_duration_as_delta, reason="Timed out via Gacha for {duration}.".format(
+        duration=mute_duration_display_str))
     Ayumi.info(
-        "Muted user ({user_name}, {user_display_name}) with role ({role_name}, {role_id}) until {unmute_time}.".format(
+        "Timed out user ({user_name}, {user_display_name}) until {unmute_time}".format(
             user_name=message.author.name,
             user_display_name=message.author.display_name,
-            role_name=role_to_add.name,
-            role_id=role_to_add.id,
-            unmute_time=unmute_time.strftime("[UTC] %c")))
+            unmute_time=unmute_time.strftime("[UTC] %c")
+        ))
 
     mute_messages = guild_settings.get("mute_messages", [DEFAULT_MUTE_MESSAGE])
     mute_message_to_use = random.choice(mute_messages)
     await message.reply(
         mute_message_to_use.format(
             muted_user_name=message.author.display_name,
-            mute_duration_display_str=intervals.convert_minutes_to_display_str(mute_duration)))
-
-    # Add the unmute_time as a record for the background task.
-    # The message object itself could technically become stale. Store this by IDs instead.
-    _muted_users.put((unmute_time, message.author.id, message.guild.id, mute_role_id))
+            mute_duration_display_str=mute_duration_display_str))
 
 
 def main():


### PR DESCRIPTION
This PR:

1. Uses Discord's [Native Timeout](https://support.discord.com/hc/en-us/articles/4413305239191-Time-Out-FAQ) feature to issue timeouts. This limits the timeouts we can set to 28 days, which has been temporarily coded in as an auto-reduction.
2. Adds external sharding support into the Dynaconf settings, so future upgrades can have zero downtime.