### PR TITLE
Add support for Administrator users

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -22,14 +22,26 @@ triggers = ["<list_of_words>"] # Words will be searched for in the message conte
 # Supported Tags:
 # {muted_user_name}
 # {mute_duration_display_str}
-# These messages are randomly selected by the bot to respond.
-mute_messages = ["<list_of_messages>"]
+# These messages are randomly selected by the bot to respond to if the user is rolling for themselves.
+mute_messages_self = ["<list_of_messages>"]
+
+# Supported Tags:
+# {muted_user_name}
+# {mute_duration_display_str}
+# These messages are randomly selected by the bot to respond if the user is rolling for others.
+muted_messages_other = ["<list_of_message>"]
 
 # Supported Tags:
 # {safe_user_name}
 # {mute_duration_display_str}
-# These messages are randomly selected by the bot to respond.
-safe_messages = ["<list_of_messages>"]
+# These messages are randomly selected by the bot to respond if the user is rolling for themselves.
+safe_messages_self = ["<list_of_messages>"]
+
+# Supported Tags:
+# {safe_user_name}
+# {mute_duration_display_str}
+# These messages are randomly selected by the bot to respond if the user is rolling for others.
+safe_messages_other = ["<list_of_messages>"]
 
 # Supported Tags:
 # {author_name}

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -29,7 +29,7 @@ mute_messages_self = ["<list_of_messages>"]
 # {muted_user_name}
 # {mute_duration_display_str}
 # These messages are randomly selected by the bot to respond if the user is rolling for others.
-muted_messages_other = ["<list_of_message>"]
+mute_messages_other = ["<list_of_message>"]
 
 # Supported Tags:
 # {safe_user_name}

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -8,11 +8,13 @@ bot_shard_count = 1
 # Channels that should be observed.
 channels = ["<list_of_channel_ids_as_int>"]
 
-# The role that should be given to users to mute them
-mute_role = "<mute_role_id_as_int>"
-
 # Roles that should not be subject to a mute event.
 safe_roles = ["<list_of_role_ids_as_int>"]
+
+# Roles that are conferred administrator-like abilities.
+# This grants the ability for users with this role to role for other users.
+# Note that admin roles are implicitly also safe roles.
+admin_roles = ["<list_of_role_ids_as_int>"]
 
 # Words, that if detected within a message, will trigger the Roulette
 triggers = ["<list_of_words>"] # Words will be searched for in the message content.
@@ -28,6 +30,11 @@ mute_messages = ["<list_of_messages>"]
 # {mute_duration_display_str}
 # These messages are randomly selected by the bot to respond.
 safe_messages = ["<list_of_messages>"]
+
+# Supported Tags:
+# {author_name}
+# These messages are used by the bot to warn non-admin users who attempt to run a command that requires admin roles.
+admin_no_role_messages = ["<list_of_messages>"]
 
 # List of Mute intervals
 # Bounds are inclusive (bound.lower, bound.upper)

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from discord.ext.commands import Bot
 
 DEFAULT_SAFE_MESSAGE = "You have a safe role, so you won't be muted :)"
 DEFAULT_MUTE_MESSAGE = "Oh no, you've been muted for {mute_duration_display_str}!"
+DEFAULT_ADMIN_NO_ROLES_MESSAGE = "You do not have sufficient permissions to run this command."
 
 intents = Intents.default()
 intents.message_content = True  # Enable sending messages
@@ -107,14 +108,26 @@ async def on_message(message: Message):
                 author_display_name=message.author.display_name,
                 message_content=message.content[:10]))
 
-    mute_duration = intervals.generate_mute_time()  # Mute duration is in minutes (as int)
-    mute_duration_display_str = intervals.convert_minutes_to_display_str(mute_duration)
-    Ayumi.info(
-        "Generated mute time: {mute_time} ({mute_time_in_minutes} minutes).".format(
-            mute_time=mute_duration_display_str,
-            mute_time_in_minutes=mute_duration))
+    admin_roles = guild_settings.get("admin_roles", list())
+    if admin_roles:
+        Ayumi.debug("Loaded admin role IDs: {ids}".format(ids=", ".join([str(role) for role in admin_roles])))
+    else:
+        Ayumi.warning("No admin role IDs were loaded.")
 
-    # If the message author is a safe role, then do not mute them.
+    # When message content contains mentions of other users, this is interpreted as a request to execute the gacha
+    # on all mentions' behalf. This requires administrator-level privileges.
+    if message.mentions and set([role.id for role in message.author.roles]).isdisjoint(admin_roles):
+        Ayumi.info("Message contains tags of other users, but user does not have an admin role, ignoring.")
+        admin_no_role_messages = guild_settings.get("admin_no_role_messages", [DEFAULT_ADMIN_NO_ROLES_MESSAGE])
+        admin_no_role_message_to_use = random.choice(admin_no_role_messages)
+        await message.reply(
+            admin_no_role_message_to_use.format(
+                author_name=message.author.name
+            )
+        )
+        return
+
+    # Preload safe roles for future processing. If the message author is a safe role, then do not mute them.
     # However, they should still be informed of their theoretical mute duration.
     safe_roles = guild_settings.get("safe_roles", list())
     if safe_roles:
@@ -122,49 +135,66 @@ async def on_message(message: Message):
     else:
         Ayumi.warning("No safe role IDs were loaded.")
 
-    # TODO: Log which role on the author is safe.
-    if not set([role.id for role in message.author.roles]).isdisjoint(safe_roles):
-        Ayumi.info("Message {message_id} from user {author_name} has a safe role, ignoring.".format(
-            message_id=message.id,
-            author_name=message.author.name))
+    # Admin roles are implicitly also safe roles, so include them in the list.
+    safe_roles.extend(admin_roles)
+    Ayumi.debug("Extended safe roles to include admin role IDs: {ids}".format(ids=", ".join([str(role) for role in admin_roles])))
 
-        safe_messages = guild_settings.get("safe_messages", [DEFAULT_SAFE_MESSAGE])
-        safe_message_to_use = random.choice(safe_messages)
+    # Select the intended action target for this message.
+    # If author has mentioned other users, they are the target. Otherwise, the target defaults to the author.
+    # Note: `dict.fromkeys()` is used to remove duplicate tags.
+    target_users = tuple(dict.fromkeys(message.mentions or [message.author]))
+
+    # Start processing an action for each target_user (either the message author, or all tagged in the message).
+    for target_user in target_users:
+        mute_duration = intervals.generate_mute_time()  # Mute duration is in minutes (as int)
+        mute_duration_display_str = intervals.convert_minutes_to_display_str(mute_duration)
+        Ayumi.info(
+            "Generated mute time: {mute_time} ({mute_time_in_minutes} minutes).".format(
+                mute_time=mute_duration_display_str,
+                mute_time_in_minutes=mute_duration))
+
+        # TODO: Log which role on the author is safe.
+        if not set([role.id for role in target_user.roles]).isdisjoint(safe_roles):
+            Ayumi.info("Message {message_id} from user {author_name} has a safe role, ignoring.".format(
+                message_id=message.id,
+                author_name=target_user.name))
+
+            safe_messages = guild_settings.get("safe_messages", [DEFAULT_SAFE_MESSAGE])
+            safe_message_to_use = random.choice(safe_messages)
+            await message.reply(safe_message_to_use.format(
+                    safe_user_name=target_user.display_name,
+                    mute_duration_display_str=mute_duration_display_str))
+            continue
+
+        # Calculate the time that the user will be unblocked.
+        current_time = datetime.now(timezone.utc)  # UTC time
+        Ayumi.debug("The current time is: {current_time}".format(current_time=current_time.strftime("[UTC] %c")))
+
+        mute_duration_as_delta = timedelta(minutes=mute_duration)
+
+        # TODO: Temporary block due to the Discord timeout being limited to 28 days.
+        if mute_duration_as_delta > timedelta(days=28):
+            mute_duration_as_delta = timedelta(days=28)
+            Ayumi.warning("WARNING: Generated a mute time above 28 days, trimming to 28 days. Check your configuration!")
+
+        unmute_time = current_time + mute_duration_as_delta
+        Ayumi.debug("The user will be unmuted at: {unmute_time}".format(unmute_time=unmute_time.strftime("[UTC] %c")))
+
+        await target_user.timeout(mute_duration_as_delta, reason="Timed out via Gacha for {duration}.".format(
+            duration=mute_duration_display_str))
+        Ayumi.info(
+            "Timed out user ({user_name}, {user_display_name}) until {unmute_time}".format(
+                user_name=target_user.name,
+                user_display_name=target_user.display_name,
+                unmute_time=unmute_time.strftime("[UTC] %c")
+            ))
+
+        mute_messages = guild_settings.get("mute_messages", [DEFAULT_MUTE_MESSAGE])
+        mute_message_to_use = random.choice(mute_messages)
         await message.reply(
-            safe_message_to_use.format(
-                safe_user_name=message.author.display_name,
+            mute_message_to_use.format(
+                muted_user_name=target_user.display_name,
                 mute_duration_display_str=mute_duration_display_str))
-        return
-
-    # Calculate the time that the user will be unblocked.
-    current_time = datetime.now(timezone.utc)  # UTC time
-    Ayumi.debug("The current time is: {current_time}".format(current_time=current_time.strftime("[UTC] %c")))
-
-    mute_duration_as_delta = timedelta(minutes=mute_duration)
-
-    # TODO: Temporary block due to the Discord timeout being limited to 28 days.
-    if mute_duration_as_delta > timedelta(days=28):
-        mute_duration_as_delta = timedelta(days=28)
-        Ayumi.warning("WARNING: Generated a mute time above 28 days, trimming to 28 days. Check your configuration!")
-
-    unmute_time = current_time + mute_duration_as_delta
-    Ayumi.debug("The user will be unmuted at: {unmute_time}".format(unmute_time=unmute_time.strftime("[UTC] %c")))
-
-    await message.author.timeout(mute_duration_as_delta, reason="Timed out via Gacha for {duration}.".format(
-        duration=mute_duration_display_str))
-    Ayumi.info(
-        "Timed out user ({user_name}, {user_display_name}) until {unmute_time}".format(
-            user_name=message.author.name,
-            user_display_name=message.author.display_name,
-            unmute_time=unmute_time.strftime("[UTC] %c")
-        ))
-
-    mute_messages = guild_settings.get("mute_messages", [DEFAULT_MUTE_MESSAGE])
-    mute_message_to_use = random.choice(mute_messages)
-    await message.reply(
-        mute_message_to_use.format(
-            muted_user_name=message.author.display_name,
-            mute_duration_display_str=mute_duration_display_str))
 
 
 def main():


### PR DESCRIPTION
This PR creates the concept of 'Administrator' users. They:

- Are implicitly SAFE users
- Can run the mute roll on behalf of another user