### PR TITLE
Introduce Tiered Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ COPY requirements.txt /opt/requirements.txt
 RUN pip install -r /opt/requirements.txt && rm /opt/requirements.txt
 
 COPY *.py /roulette/
+COPY intervals/*.py /roulette/intervals/
+
 WORKDIR /roulette
 ENTRYPOINT ["python3", "main.py"]

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -54,6 +54,6 @@ admin_no_role_messages = ["<list_of_messages>"]
 # Weight: Non-cumulative weight for each interval.
 # Supported suffixes: m, h, d, w
 # Repeat another [[<STAGE>.intervals]] to add a new interval.
-[[default.intervals]]
+[[default.intervals.local]]
 bound = { "lower" = "1m", "upper" = "5m"}
 weight = 100

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -49,6 +49,26 @@ safe_messages_other = ["<list_of_messages>"]
 # These messages are used by the bot to warn non-admin users who attempt to run a command that requires admin roles.
 admin_no_role_messages = ["<list_of_messages>"]
 
+# Intervals can be set using a variety of different modules. The first available one, in the order below, will be used:
+# 1. DigitalOcean Function
+# 2. Local Settings
+
+# DigitalOcean Function Settings
+# Make a request to a DigitalOcean Function (or same interface) and read the data back.
+[default.intervals.digitalocean.function]
+# Enables/disables this interval module. Must be explicitly set to `true` for this module to be used.
+enabled = false
+# The URL the function is hosted at. Include the full URL.
+# Required.
+url = "https://faas-<region>-<id>.doserverless.co/api/v1/web/fn-<fn_id>/your/function/path"
+# For Secure Web Functions.
+# Optional.
+auth_token = "<whisk_auth_token>"
+# Timeout before failing the request and moving to the next available module.
+# Optional.
+timeout = 0
+
+# Local Settings
 # List of Mute intervals
 # Bounds are inclusive (bound.lower, bound.upper)
 # Weight: Non-cumulative weight for each interval.

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -65,8 +65,9 @@ url = "https://faas-<region>-<id>.doserverless.co/api/v1/web/fn-<fn_id>/your/fun
 # Optional.
 auth_token = "<whisk_auth_token>"
 # Timeout before failing the request and moving to the next available module.
+# Must be set to a value greater than 0.
 # Optional.
-timeout = 0
+timeout = 1
 
 # Local Settings
 # List of Mute intervals

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -1,4 +1,5 @@
 
+[default]
 bot_token = "<bot_token>"
 bot_shard_id = 0
 bot_shard_count = 1

--- a/config/settings.toml
+++ b/config/settings.toml
@@ -59,6 +59,21 @@ admin_no_role_messages = ["<list_of_messages>"]
 # Enables/disables this interval module. Must be explicitly set to `true` for this module to be used.
 enabled = false
 # The URL the function is hosted at. Include the full URL.
+# The request will be made argumentless and bodyless.
+# Expected request return format example:
+# {
+#     "action": {
+#         "timeout": {
+#             "duration_display_str": "43 minutes" # str
+#             "duration_mins": 43 # uint, > 0
+#             "lower_bound_display_str": "1m" # str
+#             "lower_bound_mins": 1 # uint, > 0
+#             "upper_bound_display_str": "1h" # str
+#             "upper_bound_mins": 60 # uint, > 0
+#         }
+#         "type": "TIMEOUT" # Possible values: ["TIMEOUT"]
+#     }
+# }
 # Required.
 url = "https://faas-<region>-<id>.doserverless.co/api/v1/web/fn-<fn_id>/your/function/path"
 # For Secure Web Functions.

--- a/intervals/digital_ocean_function.py
+++ b/intervals/digital_ocean_function.py
@@ -54,6 +54,9 @@ def generate_mute_time() -> int:
 
     res = requests.get(url)
     if res.status_code != 200:
+        Ayumi.warning("Received status code from DigitalOcean Function: {code}".format(
+            code=str(res.status_code)
+        ))
         raise RuntimeError("DigitalOcean Function did not return a code 200.")
 
     res_data = res.json()
@@ -63,4 +66,7 @@ def generate_mute_time() -> int:
         raise ValueError("DigitalOcean Function did not return a valid response.")
 
     # Values are guaranteed to exist by Cerberus.
+    Ayumi.debug("Received a mute time of {duration} from the function.".format(
+        duration=res_data['action']['timeout']['duration_display_str']
+    ))
     return res_data['action']['timeout']['duration_mins']

--- a/intervals/digital_ocean_function.py
+++ b/intervals/digital_ocean_function.py
@@ -51,14 +51,20 @@ def generate_mute_time() -> int:
     if not url:
         raise ValueError("DigitalOcean Function interval module is active, but no URL is set.")
 
-    # TODO: Add timeout support
-
     headers = dict()
     if auth_token := interval_settings.get("auth_token"):
         Ayumi.debug("DigitalOcean Function auth token exists, added to headers.")
         headers[_WHISK_AUTH_TOKEN_HEADER] = auth_token
 
-    res = requests.get(url, headers=headers)
+    # Explicitly default to `None` to signify there is no timeout by default.
+    timeout = interval_settings.get("timeout", None)
+    Ayumi.debug("DigitalOcean Function request timeout set to: {timeout}".format(
+        timeout=str(timeout)
+    ))
+
+    # If the request times out, it should be caught by the parent module.
+    res = requests.get(url, headers=headers, timeout=timeout)
+
     if res.status_code != 200:
         raise RuntimeError("DigitalOcean Function returned code {code}.".format(
             code=str(res.status_code)

--- a/intervals/digital_ocean_function.py
+++ b/intervals/digital_ocean_function.py
@@ -1,0 +1,3 @@
+def generate_mute_time() -> int:
+    # TODO: Implement this function.
+    return 1

--- a/intervals/digital_ocean_function.py
+++ b/intervals/digital_ocean_function.py
@@ -40,6 +40,7 @@ _WHISK_AUTH_TOKEN_HEADER = "X-Require-Whisk-Auth"
 
 _validator = Validator(_RESPONSE_SCHEMA, allow_unknown=True, require_all=True)
 
+
 def generate_mute_time() -> int:
     # Load parent settings
     all_interval_settings = settings.get("intervals") or dict()

--- a/intervals/digital_ocean_function.py
+++ b/intervals/digital_ocean_function.py
@@ -1,3 +1,66 @@
+import requests
+
+from ayumi import Ayumi
+from config import settings
+from cerberus import Validator
+
+"""
+TODO: Determine whether to integrate or remove extra keys.
+
+Currently, only the `duration_mins` key will actually be used.
+"""
+_RESPONSE_SCHEMA = {
+    'action': {
+        'type': 'dict',
+        'required': True,
+        'schema': {
+            'timeout': {
+                'type': 'dict',
+                'required': True,
+                'schema': {
+                    'duration_display_str': {'type': 'string'},
+                    'duration_mins': {'type': 'integer', 'min': 1},
+                    'lower_bound_display_str': {'type': 'string'},
+                    'lower_bound_mins': {'type': 'integer', 'min': 1},
+                    'upper_bound_display_str': {'type': 'string'},
+                    'upper_bound_mins': {'type': 'integer', 'min': 1}
+                }
+            },
+            # Note: This is a literal key called "type".
+            'type': {
+                'type': 'string',
+                'allowed': ['TIMEOUT'],
+                'required': True
+            }
+        }
+    }
+}
+
+_validator = Validator(_RESPONSE_SCHEMA, allow_unknown=True, require_all=True)
+
 def generate_mute_time() -> int:
-    # TODO: Implement this function.
-    return 1
+    # Load parent settings
+    all_interval_settings = settings.get("intervals") or dict()
+    digitalocean_interval_settings = all_interval_settings.get("digitalocean", dict())
+    # Load interval settings used for this module
+    interval_settings = digitalocean_interval_settings.get("function", dict())
+
+    url = interval_settings.get("url")
+    if not url:
+        raise ValueError("DigitalOcean Function interval module is active, but no URL is set.")
+
+    # TODO: Add header support
+    # TODO: Add timeout support
+
+    res = requests.get(url)
+    if res.status_code != 200:
+        raise RuntimeError("DigitalOcean Function did not return a code 200.")
+
+    res_data = res.json()
+
+    # Validate the response
+    if not _validator.validate(res_data):
+        raise ValueError("DigitalOcean Function did not return a valid response.")
+
+    # Values are guaranteed to exist by Cerberus.
+    return res_data['action']['timeout']['duration_mins']

--- a/intervals/intervals.py
+++ b/intervals/intervals.py
@@ -11,8 +11,10 @@ if not all_interval_settings:
     Ayumi.critical("Interval settings are missing. Please check your configuration, now exiting.")
     sys.exit(1)
 
-_DIGITALOCEAN_FUNCTION_ENABLED = all_interval_settings.get("digitalocean", dict()).get("function", dict()).get("enabled", False)
+_DIGITALOCEAN_FUNCTION_ENABLED = all_interval_settings.get("digitalocean", dict()).get("function", dict()).get(
+    "enabled", False)
 Ayumi.info("DigitalOcean Function Enabled: {}".format(str(_DIGITALOCEAN_FUNCTION_ENABLED)))
+
 
 def generate_mute_time() -> int:
     if (_DIGITALOCEAN_FUNCTION_ENABLED):

--- a/intervals/intervals.py
+++ b/intervals/intervals.py
@@ -2,6 +2,7 @@ import sys
 
 from ayumi import Ayumi
 from config import settings
+from requests.exceptions import Timeout as RequestTimeout
 
 from . import digital_ocean_function, local
 
@@ -18,7 +19,7 @@ def generate_mute_time() -> int:
         Ayumi.debug("Trying to load an interval from DigitalOcean Function.")
         try:
             return digital_ocean_function.generate_mute_time()
-        except (RuntimeError, ValueError) as e:
+        except (RequestTimeout, RuntimeError, ValueError) as e:
             Ayumi.critical("DigitalOcean Function encountered an error: {}".format(e))
 
     # Local settings is guaranteed to return a value.

--- a/intervals/intervals.py
+++ b/intervals/intervals.py
@@ -1,7 +1,26 @@
+import sys
+
+from ayumi import Ayumi
 from config import settings
 
-from . import local
+from . import digital_ocean_function, local
 
+all_interval_settings = settings.get("intervals")
+if not all_interval_settings:
+    Ayumi.critical("Interval settings are missing. Please check your configuration, now exiting.")
+    sys.exit(1)
+
+_DIGITALOCEAN_FUNCTION_ENABLED = all_interval_settings.get("digitalocean", dict()).get("function", dict()).get("enabled", False)
+Ayumi.info("DigitalOcean Function Enabled: {}".format(str(_DIGITALOCEAN_FUNCTION_ENABLED)))
 
 def generate_mute_time() -> int:
+    if (_DIGITALOCEAN_FUNCTION_ENABLED):
+        Ayumi.debug("Trying to load an interval from DigitalOcean Function.")
+        try:
+            return digital_ocean_function.generate_mute_time()
+        except ValueError as e:
+            Ayumi.critical("DigitalOcean Function encountered an error: {}".format(e))
+
+    # Local settings is guaranteed to return a value.
+    Ayumi.debug("Loading interval from local settings.")
     return local.generate_mute_time()

--- a/intervals/intervals.py
+++ b/intervals/intervals.py
@@ -1,0 +1,7 @@
+from config import settings
+
+from . import local
+
+
+def generate_mute_time() -> int:
+    return local.generate_mute_time()

--- a/intervals/intervals.py
+++ b/intervals/intervals.py
@@ -18,7 +18,7 @@ def generate_mute_time() -> int:
         Ayumi.debug("Trying to load an interval from DigitalOcean Function.")
         try:
             return digital_ocean_function.generate_mute_time()
-        except ValueError as e:
+        except (RuntimeError, ValueError) as e:
             Ayumi.critical("DigitalOcean Function encountered an error: {}".format(e))
 
     # Local settings is guaranteed to return a value.

--- a/intervals/local.py
+++ b/intervals/local.py
@@ -4,11 +4,25 @@ from ayumi import Ayumi
 from config import settings
 from .time_display_converter import convert_interval_str_to_minutes, convert_minutes_to_display_str
 
+# A default interval to fall back to, if the user has not set any.
+_DEFAULT_INTERVAL = {
+    "bound": {
+        "lower": "1m",
+        "upper": "5m"
+    },
+    "weight": 100
+}
+
 
 def generate_mute_time() -> int:
     # Load the list of intervals used to determine mutes.
-    intervals = settings.get("intervals")
+    interval_settings = settings.get("intervals") or dict()
+    intervals = interval_settings.get("local", list())
     Ayumi.debug("Loaded {count} intervals.".format(count=int(len(intervals))))
+
+    if not intervals:
+        intervals = [_DEFAULT_INTERVAL]
+        Ayumi.warning("No local interval settings were set or found. Using default fallback!")
 
     # First, select an interval to load
     # Create the bounds tuples and their respective weights

--- a/intervals/local.py
+++ b/intervals/local.py
@@ -22,7 +22,7 @@ def generate_mute_time() -> int:
 
     if not intervals:
         intervals = [_DEFAULT_INTERVAL]
-        Ayumi.warning("No local interval settings were set or found. Using default fallback!")
+        Ayumi.warning("No local interval settings were set or found - using default fallback.")
 
     # First, select an interval to load
     # Create the bounds tuples and their respective weights

--- a/intervals/local.py
+++ b/intervals/local.py
@@ -1,0 +1,31 @@
+import random
+
+from ayumi import Ayumi
+from config import settings
+from .time_display_converter import convert_interval_str_to_minutes, convert_minutes_to_display_str
+
+
+def generate_mute_time() -> int:
+    # Load the list of intervals used to determine mutes.
+    intervals = settings.get("intervals")
+    Ayumi.debug("Loaded {count} intervals.".format(count=int(len(intervals))))
+
+    # First, select an interval to load
+    # Create the bounds tuples and their respective weights
+    bounds = [interval["bound"] for interval in intervals]
+    weights = [int(interval["weight"]) for interval in intervals]
+    interval = random.choices(bounds, weights=weights, k=1)[0]
+
+    # From the interval, randomly select a time.
+    # The interval is a Tuple[lower_bound: str, upper_bound: str]
+    lower_bound = convert_interval_str_to_minutes(interval["lower"])
+    upper_bound = convert_interval_str_to_minutes(interval["upper"])
+
+    mute_duration = random.randint(lower_bound, upper_bound)
+    Ayumi.debug(
+        "Selected mute duration: ({mute_duration}) from lower bound: ({lower_bound}) and upper bound: ({upper_bound}).".format(
+            mute_duration=convert_minutes_to_display_str(mute_duration),
+            lower_bound=convert_minutes_to_display_str(lower_bound),
+            upper_bound=convert_minutes_to_display_str(upper_bound)))
+
+    return mute_duration

--- a/intervals/time_display_converter.py
+++ b/intervals/time_display_converter.py
@@ -1,8 +1,3 @@
-import random
-
-from ayumi import Ayumi
-from config import settings
-
 
 _WEEKS_IN_MINUTES = 10080
 _DAYS_IN_MINUTES = 1440
@@ -45,28 +40,3 @@ def convert_minutes_to_display_str(minutes: int, granularity=2) -> str:
     start, _, end = ', '.join(result[:granularity]).rpartition(',')
     return start + " and" + end if start else end
 
-
-def generate_mute_time() -> int:
-    # Load the list of intervals used to determine mutes.
-    intervals = settings.get("intervals")
-    Ayumi.debug("Loaded {count} intervals.".format(count=int(len(intervals))))
-
-    # First, select an interval to load
-    # Create the bounds tuples and their respective weights
-    bounds = [interval["bound"] for interval in intervals]
-    weights = [int(interval["weight"]) for interval in intervals]
-    interval = random.choices(bounds, weights=weights, k=1)[0]
-
-    # From the interval, randomly select a time.
-    # The interval is a Tuple[lower_bound: str, upper_bound: str]
-    lower_bound = convert_interval_str_to_minutes(interval["lower"])
-    upper_bound = convert_interval_str_to_minutes(interval["upper"])
-
-    mute_duration = random.randint(lower_bound, upper_bound)
-    Ayumi.debug(
-        "Selected mute duration: ({mute_duration}) from lower bound: ({lower_bound}) and upper bound: ({upper_bound}).".format(
-            mute_duration=convert_minutes_to_display_str(mute_duration),
-            lower_bound=convert_minutes_to_display_str(lower_bound),
-            upper_bound=convert_minutes_to_display_str(upper_bound)))
-
-    return mute_duration

--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
 import random
 import sys
 
-import requests
-
 from ayumi import Ayumi
 from config import settings
 from datetime import datetime, timedelta, timezone

--- a/main.py
+++ b/main.py
@@ -1,13 +1,15 @@
 import random
 import sys
 
-import intervals
+import requests
 
 from ayumi import Ayumi
 from config import settings
 from datetime import datetime, timedelta, timezone
 from discord import Intents, Message
 from discord.ext.commands import Bot
+from intervals import intervals
+from intervals import time_display_converter as tdc
 
 # TODO: Add support for Cogs/Extensions
 
@@ -155,63 +157,67 @@ async def on_message(message: Message):
 
     target_users = target_users[:5]  # Trim to only support up to 5 tags at most currently.
 
-    # Start processing an action for each target_user (either the message author, or all tagged in the message).
-    for target_user in target_users:
-        mute_duration = intervals.generate_mute_time()  # Mute duration is in minutes (as int)
-        mute_duration_display_str = intervals.convert_minutes_to_display_str(mute_duration)
-        Ayumi.info(
-            "Generated mute time: {mute_time} ({mute_time_in_minutes} minutes).".format(
-                mute_time=mute_duration_display_str,
-                mute_time_in_minutes=mute_duration))
+    # Because requests may take long, send a typing indicator so the author knows processing is occuring.
+    async with message.channel.typing():
 
-        target_is_self = (target_user == message.author)
-        Ayumi.debug(f"Target for mute is self: {target_is_self}")
+        # Start processing an action for each target_user (either the message author, or all tagged in the message).
+        for target_user in target_users:
+            mute_duration = intervals.generate_mute_time()  # Mute duration is in minutes (as int)
 
-        # TODO: Log which role on the author is safe.
-        if not set([role.id for role in target_user.roles]).isdisjoint(safe_roles):
-            Ayumi.info("Message {message_id} for user {author_name} has a safe role, ignoring.".format(
-                message_id=message.id,
-                author_name=target_user.name))
+            mute_duration_display_str = tdc.convert_minutes_to_display_str(mute_duration)
+            Ayumi.info(
+                "Generated mute time: {mute_time} ({mute_time_in_minutes} minutes).".format(
+                    mute_time=mute_duration_display_str,
+                    mute_time_in_minutes=mute_duration))
 
-            safe_messages = guild_settings.get("safe_messages_self", [DEFAULT_SAFE_MESSAGE_SELF]) \
-                if target_is_self else guild_settings.get("safe_messages_other", [DEFAULT_SAFE_MESSAGE_OTHER])
-            safe_message_to_use = random.choice(safe_messages)
-            await message.reply(safe_message_to_use.format(
-                safe_user_name=target_user.display_name,
-                mute_duration_display_str=mute_duration_display_str))
-            continue
+            target_is_self = (target_user == message.author)
+            Ayumi.debug(f"Target for mute is self: {target_is_self}")
 
-        # Calculate the time that the user will be unblocked.
-        current_time = datetime.now(timezone.utc)  # UTC time
-        Ayumi.debug("The current time is: {current_time}".format(current_time=current_time.strftime("[UTC] %c")))
+            # TODO: Log which role on the author is safe.
+            if not set([role.id for role in target_user.roles]).isdisjoint(safe_roles):
+                Ayumi.info("Message {message_id} for user {author_name} has a safe role, ignoring.".format(
+                    message_id=message.id,
+                    author_name=target_user.name))
 
-        mute_duration_as_delta = timedelta(minutes=mute_duration)
+                safe_messages = guild_settings.get("safe_messages_self", [DEFAULT_SAFE_MESSAGE_SELF]) \
+                    if target_is_self else guild_settings.get("safe_messages_other", [DEFAULT_SAFE_MESSAGE_OTHER])
+                safe_message_to_use = random.choice(safe_messages)
+                await message.reply(safe_message_to_use.format(
+                    safe_user_name=target_user.display_name,
+                    mute_duration_display_str=mute_duration_display_str))
+                continue
 
-        # TODO: Temporary block due to the Discord timeout being limited to 28 days.
-        if mute_duration_as_delta > timedelta(days=28):
-            mute_duration_as_delta = timedelta(days=28)
-            Ayumi.warning(
-                "WARNING: Generated a mute time above 28 days, trimming to 28 days. Check your configuration!")
+            # Calculate the time that the user will be unblocked.
+            current_time = datetime.now(timezone.utc)  # UTC time
+            Ayumi.debug("The current time is: {current_time}".format(current_time=current_time.strftime("[UTC] %c")))
 
-        unmute_time = current_time + mute_duration_as_delta
-        Ayumi.debug("The user will be unmuted at: {unmute_time}".format(unmute_time=unmute_time.strftime("[UTC] %c")))
+            mute_duration_as_delta = timedelta(minutes=mute_duration)
 
-        await target_user.timeout(mute_duration_as_delta, reason="Timed out via Gacha for {duration}.".format(
-            duration=mute_duration_display_str))
-        Ayumi.info(
-            "Timed out user ({user_name}, {user_display_name}) until {unmute_time}".format(
-                user_name=target_user.name,
-                user_display_name=target_user.display_name,
-                unmute_time=unmute_time.strftime("[UTC] %c")
-            ))
+            # TODO: Temporary block due to the Discord timeout being limited to 28 days.
+            if mute_duration_as_delta > timedelta(days=28):
+                mute_duration_as_delta = timedelta(days=28)
+                Ayumi.warning(
+                    "WARNING: Generated a mute time above 28 days, trimming to 28 days. Check your configuration!")
 
-        mute_messages = guild_settings.get("mute_messages_self", [DEFAULT_MUTE_MESSAGE_SELF]) \
-            if target_is_self else guild_settings.get("mute_messages_other", [DEFAULT_MUTE_MESSAGE_OTHER])
-        mute_message_to_use = random.choice(mute_messages)
-        await message.reply(
-            mute_message_to_use.format(
-                muted_user_name=target_user.display_name,
-                mute_duration_display_str=mute_duration_display_str))
+            unmute_time = current_time + mute_duration_as_delta
+            Ayumi.debug("The user will be unmuted at: {unmute_time}".format(unmute_time=unmute_time.strftime("[UTC] %c")))
+
+            await target_user.timeout(mute_duration_as_delta, reason="Timed out via Gacha for {duration}.".format(
+                duration=mute_duration_display_str))
+            Ayumi.info(
+                "Timed out user ({user_name}, {user_display_name}) until {unmute_time}".format(
+                    user_name=target_user.name,
+                    user_display_name=target_user.display_name,
+                    unmute_time=unmute_time.strftime("[UTC] %c")
+                ))
+
+            mute_messages = guild_settings.get("mute_messages_self", [DEFAULT_MUTE_MESSAGE_SELF]) \
+                if target_is_self else guild_settings.get("mute_messages_other", [DEFAULT_MUTE_MESSAGE_OTHER])
+            mute_message_to_use = random.choice(mute_messages)
+            await message.reply(
+                mute_message_to_use.format(
+                    muted_user_name=target_user.display_name,
+                    mute_duration_display_str=mute_duration_display_str))
 
 
 def main():

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,11 @@ aiohttp==3.9.1
 aiosignal==1.3.1
 attrs==23.1.0
 ayumi @ git+https://github.com/shunjuu/Ayumi@2b3b99570d810b44ce7d7e43ef33a336895230a1
+Cerberus==1.3.5
 discord.py==2.3.2
 dynaconf==3.2.4
 frozenlist==1.4.1
 idna==3.6
 multidict==6.0.4
+requests==2.31.0
 yarl==1.9.4


### PR DESCRIPTION
This PR sets up a "tiered" system of configurations, that will be used sequentially. The first module within this tear supported is for DigitalOcean functions. Local interval settings are also added as a fallback, default module.

The DO module expects a return of the following form:
```
{
  "action": {
    "timeout": {
      "duration_display_str": "43 minutes",
      "duration_mins": 43,
      "lower_bound_display_str": "1m",
      "lower_bound_mins": 1,
      "upper_bound_display_str": "1h",
      "upper_bound_mins": 60
    },
    "type": "TIMEOUT"
  },
  "metadata": {
    "is_manual_value": false,
    "version": "0.0.3"
  }
}
```

Migrations required:
- Local interval times have changed from `<STAGING_ENV>.intervals` to `<STAGING_ENV>.intervals.local`

Because requests to DO can take time, the bot will now also provide a "typing" indicator from when the message *can* be processed to when the returned action is applied.